### PR TITLE
[IP-91] read test users from storage

### DIFF
--- a/HandleNHNotificationCallOrchestrator/index.ts
+++ b/HandleNHNotificationCallOrchestrator/index.ts
@@ -1,9 +1,14 @@
-﻿import * as df from "durable-functions";
+import { TelemetryClient } from "applicationinsights";
+import * as df from "durable-functions";
+import { initTelemetryClient } from "../utils/appinsights";
 import { getConfigOrThrow } from "../utils/config";
 import { getHandler } from "./handler";
 
 const config = getConfigOrThrow();
-const handler = getHandler(config);
+
+const ai = initTelemetryClient(config) as TelemetryClient;
+
+const handler = getHandler(config, ai);
 const orchestrator = df.orchestrator(handler);
 
 export default orchestrator;

--- a/IsUserInActiveSubsetActivity/__tests__/handler.test.ts
+++ b/IsUserInActiveSubsetActivity/__tests__/handler.test.ts
@@ -1,0 +1,78 @@
+import { fromEither } from "fp-ts/lib/TaskEither";
+import { isLeft, isRight, left, right } from "fp-ts/lib/Either";
+
+import { NHPartitionFeatureFlag } from "../../utils/config";
+import { getIsInActiveSubset } from "../../utils/featureFlags";
+
+import { context as contextMock } from "../../__mocks__/durable-functions";
+
+import {
+  ActivityInput,
+  ActivitySuccessWithValue,
+  getIsUserInActiveSubsetHandler
+} from "../handler";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+
+const aFiscalCodeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
+
+const userIsInActiveSubset: ReturnType<typeof getIsInActiveSubset> = _ =>
+  fromEither(right(true));
+
+const userIsNotInActiveSubset: ReturnType<typeof getIsInActiveSubset> = _ =>
+  fromEither(right(false));
+
+const userIsInActiveSubset_Error: ReturnType<typeof getIsInActiveSubset> = _ =>
+  fromEither(left(new Error("Test Error")));
+
+describe("IsUserInActiveSubsetActivity", () => {
+  it("should return true", async () => {
+    const handler = getIsUserInActiveSubsetHandler(userIsInActiveSubset);
+
+    const input = ActivityInput.encode({
+      enabledFeatureFlag: NHPartitionFeatureFlag.all,
+      sha: aFiscalCodeHash
+    });
+    var result = await handler(contextMock as any, input);
+    expect(result.kind).toBe("SUCCESS");
+
+    expect((result as any).value).toBeTruthy();
+  });
+  it("should return false", async () => {
+    const handler = getIsUserInActiveSubsetHandler(userIsNotInActiveSubset);
+
+    const input = ActivityInput.encode({
+      enabledFeatureFlag: NHPartitionFeatureFlag.all,
+      sha: aFiscalCodeHash
+    });
+    var result = await handler(contextMock as any, input);
+    expect(result.kind).toBe("SUCCESS");
+
+    expect((result as any).value).toBeFalsy();
+  });
+
+  it("should throw Exception if an error occurred in function", async () => {
+    const handler = getIsUserInActiveSubsetHandler(userIsInActiveSubset_Error);
+
+    expect.assertions(1);
+    try {
+      const input = ActivityInput.encode({
+        enabledFeatureFlag: NHPartitionFeatureFlag.all,
+        sha: aFiscalCodeHash
+      });
+      var result = await handler(contextMock as any, input);
+    } catch (e) {
+      expect(true).toBeTruthy();
+    }
+  });
+
+  it("should return Error if input is wrong", async () => {
+    const handler = getIsUserInActiveSubsetHandler(userIsInActiveSubset_Error);
+
+    const input = {
+      enabledFeatureFlag: "wrong",
+      sha: aFiscalCodeHash
+    };
+    var result = await handler(contextMock as any, input);
+    expect(result.kind).toBe("FAILURE");
+  });
+});

--- a/IsUserInActiveSubsetActivity/function.json
+++ b/IsUserInActiveSubsetActivity/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/IsUserInActiveSubsetActivity/index.js"
+}

--- a/IsUserInActiveSubsetActivity/handler.ts
+++ b/IsUserInActiveSubsetActivity/handler.ts
@@ -1,0 +1,56 @@
+import * as t from "io-ts";
+
+import { Context } from "@azure/functions";
+import { fromEither } from "fp-ts/lib/TaskEither";
+import { errorsToReadableMessages } from "italia-ts-commons/lib/reporters";
+import { enumType } from "italia-ts-commons/lib/types";
+import { InstallationId } from "../generated/notifications/InstallationId";
+import { ActivityResult, failure, getRetryActivity } from "../utils/activity";
+import { NHPartitionFeatureFlag } from "../utils/config";
+import * as featureFlags from "../utils/featureFlags";
+
+export const ActivityInput = t.interface({
+  enabledFeatureFlag: enumType<NHPartitionFeatureFlag>(
+    NHPartitionFeatureFlag,
+    "NHPartitionFeatureFlag"
+  ),
+  sha: InstallationId
+});
+
+export type ActivityInput = t.TypeOf<typeof ActivityInput>;
+
+export const ActivitySuccessWithValue = t.interface({
+  kind: t.literal("SUCCESS"),
+  value: t.boolean
+});
+
+export type ActivitySuccessWithValue = t.Type<typeof ActivitySuccessWithValue>;
+
+export function errorsToError(errors: t.Errors): Error {
+  return new Error(errorsToReadableMessages(errors).join(" / "));
+}
+
+export const successWithValue = (value: boolean) =>
+  ActivitySuccessWithValue.encode({
+    kind: "SUCCESS",
+    value
+  });
+
+export const getIsUserInActiveSubsetHandler = (
+  isInActiveSubset: ReturnType<typeof featureFlags.getIsInActiveSubset>,
+  logPrefix: string = "IsUserInActiveSubset"
+) => (context: Context, input: unknown): Promise<ActivityResult> => {
+  const fail = failure(context, logPrefix);
+  const retryActivity = getRetryActivity(context, logPrefix);
+
+  return fromEither(ActivityInput.decode(input))
+    .mapLeft(errs => fail(errorsToError(errs)))
+    .chain(({ enabledFeatureFlag, sha }) =>
+      isInActiveSubset(enabledFeatureFlag, sha).bimap(
+        e => retryActivity(e),
+        res => successWithValue(res)
+      )
+    )
+    .fold<ActivityResult>(t.identity, t.identity)
+    .run();
+};

--- a/IsUserInActiveSubsetActivity/index.ts
+++ b/IsUserInActiveSubsetActivity/index.ts
@@ -1,0 +1,17 @@
+﻿import { createTableService } from "azure-storage";
+import { getConfigOrThrow } from "../utils/config";
+import { getIsInActiveSubset } from "../utils/featureFlags";
+import { getIsUserATestUser } from "../utils/testUsersTableStorage";
+import { getIsUserInActiveSubsetHandler } from "./handler";
+
+const config = getConfigOrThrow();
+
+const tableService = createTableService(
+  config.NOTIFICATIONS_STORAGE_CONNECTION_STRING
+);
+
+const activityFunction = getIsUserInActiveSubsetHandler(
+  getIsInActiveSubset(getIsUserATestUser(tableService))
+);
+
+export default activityFunction;

--- a/IsUserInActiveSubsetActivity/index.ts
+++ b/IsUserInActiveSubsetActivity/index.ts
@@ -7,11 +7,13 @@ import { getIsUserInActiveSubsetHandler } from "./handler";
 const config = getConfigOrThrow();
 
 const tableService = createTableService(
-  config.NOTIFICATIONS_STORAGE_CONNECTION_STRING
+  config.BETA_USERS_STORAGE_CONNECTION_STRING
 );
 
 const activityFunction = getIsUserInActiveSubsetHandler(
-  getIsInActiveSubset(getIsUserATestUser(tableService))
+  getIsInActiveSubset(
+    getIsUserATestUser(tableService, config.BETA_USERS_TABLE_NAME)
+  )
 );
 
 export default activityFunction;

--- a/__mocks__/env-config.mock.ts
+++ b/__mocks__/env-config.mock.ts
@@ -1,10 +1,21 @@
 import { IConfig, NHPartitionFeatureFlag } from "../utils/config";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { IntegerFromString } from "italia-ts-commons/lib/numbers";
 
-export const envConfig = {
+export const envConfig: IConfig = {
+  isProduction: false,
+  APPINSIGHTS_INSTRUMENTATIONKEY: "Idontknow" as NonEmptyString,
+  APPINSIGHTS_SAMPLING_PERCENTAGE: ("20" as undefined) as IntegerFromString,
+
+  RETRY_ATTEMPT_NUMBER: ("1" as undefined) as IntegerFromString,
+
+  AzureWebJobsStorage: "Endpoint=sb://host.docker.internal:30000;SharedAccessKeyName=DefaultFullSharedAccessSignature;SharedAccessKey=foobar" as NonEmptyString,
+  AZURE_NH_ENDPOINT: "Endpoint=sb://host.docker.internal:30000;SharedAccessKeyName=DefaultFullSharedAccessSignature;SharedAccessKey=foobar" as NonEmptyString,
+  AZURE_NH_HUB_NAME: "io-notification-hub-mock" as NonEmptyString,
+
+  NOTIFICATIONS_STORAGE_CONNECTION_STRING: "Endpoint=sb://host.docker.internal:30000;SharedAccessKeyName=DefaultFullSharedAccessSignature;SharedAccessKey=foobar" as NonEmptyString,
+
   NH_PARTITION_FEATURE_FLAG: NHPartitionFeatureFlag.all,
-  RETRY_ATTEMPT_NUMBER: 1,
-  APPINSIGHTS_INSTRUMENTATIONKEY: "Idontknow",
-  AZURE_NH_ENDPOINT:
-    "Endpoint=sb://host.docker.internal:30000;SharedAccessKeyName=DefaultFullSharedAccessSignature;SharedAccessKey=foobar",
-  AZURE_NH_HUB_NAME: "io-notification-hub-mock"
-} as IConfig;
+  BETA_USERS_STORAGE_CONNECTION_STRING: "Endpoint=sb://host.docker.internal:30000;SharedAccessKeyName=DefaultFullSharedAccessSignature;SharedAccessKey=foobar" as NonEmptyString,
+  BETA_USERS_TABLE_NAME: "nhpartitiontestusers" as NonEmptyString
+};

--- a/env.example
+++ b/env.example
@@ -19,11 +19,19 @@ AzureWebJobsStorage=${STORAGE_CONN_STRING}
 
 RETRY_ATTEMPT_NUMBER=10
 
+NOTIFICATIONS_QUEUE_NAME=push-notifications
+NOTIFICATIONS_STORAGE_CONNECTION_STRING=${STORAGE_CONN_STRING}
+
+
+# ------------------------------------
+# Variable used during transition to new NH management
+# ------------------------------------
+
 # Possible values : "none" | "all" | "beta" | "canary"
 NH_PARTITION_FEATURE_FLAG=none
 
-NOTIFICATIONS_QUEUE_NAME=push-notifications
-NOTIFICATIONS_STORAGE_CONNECTION_STRING=${STORAGE_CONN_STRING}
+BETA_USERS_STORAGE_CONNECTION_STRING=${STORAGE_CONN_STRING}
+BETA_USERS_TABLE_NAME=nhpartitiontestusers
 
 
 # ------------------------------------

--- a/utils/__tests__/config.test.ts
+++ b/utils/__tests__/config.test.ts
@@ -1,26 +1,8 @@
-import { isLeft, isRight } from "fp-ts/lib/Either";
+import { isRight } from "fp-ts/lib/Either";
 import { IConfig } from "../config";
-import * as t from "io-ts";
-import { IntegerFromString } from "italia-ts-commons/lib/numbers";
-import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { envConfig } from "../../__mocks__/env-config.mock";
 
-const aConfig = {
-  NH_PARTITION_FEATURE_FLAG: "all",
-
-  RETRY_ATTEMPT_NUMBER: "2",
-  AZURE_NH_ENDPOINT:
-    "sb://host.docker.internal:30000;SharedAccessKeyName=DefaultFullSharedAccessSignature;SharedAccessKey=foobar",
-  AZURE_NH_HUB_NAME: "io-notification-hub-mock",
-  AzureWebJobsStorage: "connString",
-  NOTIFICATIONS_STORAGE_CONNECTION_STRING: "connString",
-
-  APPINSIGHTS_INSTRUMENTATIONKEY: "IDoNotKnow",
-  // the internal function runtime has MaxTelemetryItem per second set to 20 by default
-  // @see https://github.com/Azure/azure-functions-host/blob/master/src/WebJobs.Script/Config/ApplicationInsightsLoggerOptionsSetup.cs#L29
-  APPINSIGHTS_SAMPLING_PERCENTAGE: "20",
-
-  isProduction: false
-};
+const aConfig = envConfig;
 
 describe("IConfig", () => {
   it("should deserialize right FF input", () => {

--- a/utils/__tests__/featureFlags.test.ts
+++ b/utils/__tests__/featureFlags.test.ts
@@ -1,27 +1,40 @@
-import { isLeft, isRight } from "fp-ts/lib/Either";
+import { isLeft, isRight, right } from "fp-ts/lib/Either";
 import { IConfig, NHPartitionFeatureFlag } from "../config";
 import * as t from "io-ts";
 import { IntegerFromString } from "italia-ts-commons/lib/numbers";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import * as featureFlags from "../featureFlags";
+import { fromEither } from "fp-ts/lib/TaskEither";
 
 const aFiscalCodeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
 
-describe("IConfig", () => {
+describe("featureFlags", () => {
   it("should return `true` when feature flag `all` is enabled", () => {
-    var valueIsContained = featureFlags.isInActiveSubset(
-      NHPartitionFeatureFlag.all,
-      aFiscalCodeHash
-    );
+    expect.assertions(2);
 
-    expect(valueIsContained).toBeTruthy();
+    featureFlags
+      .getIsInActiveSubset(_ => fromEither(right(false)))(
+        NHPartitionFeatureFlag.all,
+        aFiscalCodeHash
+      )
+      .run()
+      .then(v => {
+        expect(isRight(v)).toBeTruthy();
+        expect(v.value).toBeTruthy();
+      });
   });
   it("should return `false` when feature flag `none` is enabled", () => {
-    var valueIsContained = featureFlags.isInActiveSubset(
-      NHPartitionFeatureFlag.none,
-      aFiscalCodeHash
-    );
+    expect.assertions(2);
 
-    expect(valueIsContained).toBeFalsy();
+    featureFlags
+      .getIsInActiveSubset(_ => fromEither(right(false)))(
+        NHPartitionFeatureFlag.none,
+        aFiscalCodeHash
+      )
+      .run()
+      .then(v => {
+        expect(isRight(v)).toBeTruthy();
+        expect(v.value).toBeFalsy();
+      });
   });
 });

--- a/utils/activity.ts
+++ b/utils/activity.ts
@@ -55,6 +55,20 @@ export const retryActivity = (context: Context, msg: string) => {
   throw toError(msg);
 };
 
+/**
+ * Build a retryActivity from `context` and `logPrefix`
+ * @param context
+ * @param logPrefix
+ * @returns a function that log the error and throw an exception
+ *          so that the orchestrator can retry the activity
+ */
+export const getRetryActivity = (context: Context, logPrefix: string) => (
+  e: Error
+) => retryActivity(context, `${logPrefix}|ERROR=${e.message}`);
+
+/**
+ * @returns an `ActivityResultSuccess`
+ */
 export const success = () =>
   ActivityResultSuccess.encode({
     kind: "SUCCESS"

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -22,11 +22,6 @@ export enum NHPartitionFeatureFlag {
 export type IConfig = t.TypeOf<typeof IConfig>;
 export const IConfig = t.intersection([
   t.interface({
-    NH_PARTITION_FEATURE_FLAG: enumType<NHPartitionFeatureFlag>(
-      NHPartitionFeatureFlag,
-      "NHPartitionFeatureFlag"
-    ),
-
     RETRY_ATTEMPT_NUMBER: IntegerFromString,
 
     AZURE_NH_ENDPOINT: NonEmptyString,
@@ -41,6 +36,15 @@ export const IConfig = t.intersection([
     APPINSIGHTS_SAMPLING_PERCENTAGE: withDefault(IntegerFromString, 5),
 
     isProduction: t.boolean
+  }),
+  t.interface({
+    NH_PARTITION_FEATURE_FLAG: enumType<NHPartitionFeatureFlag>(
+      NHPartitionFeatureFlag,
+      "NHPartitionFeatureFlag"
+    ),
+
+    BETA_USERS_STORAGE_CONNECTION_STRING: NonEmptyString,
+    BETA_USERS_TABLE_NAME: NonEmptyString
   }),
   t.partial({ APPINSIGHTS_DISABLE: t.string })
 ]);

--- a/utils/featureFlags.ts
+++ b/utils/featureFlags.ts
@@ -1,3 +1,5 @@
+import { right } from "fp-ts/lib/Either";
+import { fromEither, TaskEither } from "fp-ts/lib/TaskEither";
 import { InstallationId } from "../generated/notifications/InstallationId";
 import { NHPartitionFeatureFlag } from "./config";
 
@@ -7,25 +9,25 @@ import { NHPartitionFeatureFlag } from "./config";
  * @param sha the installation id of the user
  * @returns `true` if the user is enabled for the new feature, `false` otherwise
  */
-export function isInActiveSubset(
+export const getIsInActiveSubset = (
+  isUserATestUser: (InstallationId) => TaskEither<Error, boolean>
+) => (
   enabledFeatureFlag: NHPartitionFeatureFlag,
-  // tslint:disable-next-line: no-unused-variable
   sha: InstallationId
-): boolean {
+): TaskEither<Error, boolean> => {
   switch (enabledFeatureFlag) {
     case NHPartitionFeatureFlag.all:
-      return true;
+      return fromEither(right(true));
 
     case NHPartitionFeatureFlag.beta:
-      // Todo
-      return false;
+      return isUserATestUser(sha);
 
     case NHPartitionFeatureFlag.canary:
       // Todo
-      return false;
+      return fromEither(right(false));
 
     case NHPartitionFeatureFlag.none:
     default:
-      return false;
+      return fromEither(right(false));
   }
-}
+};

--- a/utils/orchestrators.ts
+++ b/utils/orchestrators.ts
@@ -1,0 +1,20 @@
+import * as ai from "applicationinsights";
+import { IOrchestrationFunctionContext } from "durable-functions/lib/src/iorchestrationfunctioncontext";
+import * as t from "io-ts";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+
+export const trackExceptionAndThrow = (
+  context: IOrchestrationFunctionContext,
+  aiTelemetry: ai.TelemetryClient,
+  logPrefix: string
+) => (err: Error | t.Errors, name: string) => {
+  const errMessage = err instanceof Error ? err.message : readableReport(err);
+  context.log.verbose(`${logPrefix}|ERROR=${errMessage}`);
+  aiTelemetry.trackException({
+    exception: new Error(`${logPrefix}|ERROR=${errMessage}`),
+    properties: {
+      name
+    }
+  });
+  throw new Error(errMessage);
+};

--- a/utils/testUsersTableStorage.ts
+++ b/utils/testUsersTableStorage.ts
@@ -1,0 +1,33 @@
+import { TableQuery, TableService } from "azure-storage";
+import { toError } from "fp-ts/lib/Either";
+import { TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
+import { InstallationId } from "../generated/notifications/InstallationId";
+
+const tryUserExists = (
+  tableService: TableService,
+  sha: InstallationId
+): Promise<boolean> =>
+  new Promise((resolve, reject) => {
+    const query = new TableQuery().where("RowKey eq ?", sha);
+
+    tableService.queryEntities(
+      "nhpartitiontestusers",
+      query,
+      null,
+      (error, result, response) => {
+        if (response.isSuccessful) {
+          resolve(result.entries.length > 0);
+        } else {
+          reject(error);
+        }
+      }
+    );
+  });
+
+/**
+ * Returns a paged query function for a certain query on a storage table
+ */
+export const getIsUserATestUser = (tableService: TableService) => (
+  sha: InstallationId
+): TaskEither<Error, boolean> =>
+  tryCatch(() => tryUserExists(tableService, sha), toError);

--- a/utils/testUsersTableStorage.ts
+++ b/utils/testUsersTableStorage.ts
@@ -5,13 +5,14 @@ import { InstallationId } from "../generated/notifications/InstallationId";
 
 const tryUserExists = (
   tableService: TableService,
+  tableName: string,
   sha: InstallationId
 ): Promise<boolean> =>
   new Promise((resolve, reject) => {
     const query = new TableQuery().where("RowKey eq ?", sha);
 
     tableService.queryEntities(
-      "nhpartitiontestusers",
+      tableName,
       query,
       null,
       (error, result, response) => {
@@ -27,7 +28,8 @@ const tryUserExists = (
 /**
  * Returns a paged query function for a certain query on a storage table
  */
-export const getIsUserATestUser = (tableService: TableService) => (
-  sha: InstallationId
-): TaskEither<Error, boolean> =>
-  tryCatch(() => tryUserExists(tableService, sha), toError);
+export const getIsUserATestUser = (
+  tableService: TableService,
+  tableName: string
+) => (sha: InstallationId): TaskEither<Error, boolean> =>
+  tryCatch(() => tryUserExists(tableService, tableName, sha), toError);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Added new `IsUserInActiveSubsetActivity` activity
- Added mechanism to search `beta` users within a storage account table
- Updated orchestrator accordingly
- Updated tests accordingly

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
IP-27 We need a Feture Flag mechanism that can allow to test the new feature only for a subset of users so we can gradually release the new NH implementation

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests and integration test using sandbox NH

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
