### PR TITLE
[IP-94] Check canary users with regex

### DIFF
--- a/IsUserInActiveSubsetActivity/index.ts
+++ b/IsUserInActiveSubsetActivity/index.ts
@@ -1,8 +1,9 @@
-﻿import { getConfigOrThrow } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { createActivity } from "../utils/durable/activities";
 import {
   getIsInActiveSubset,
-  getIsUserABetaTestUser
+  getIsUserABetaTestUser,
+  getIsUserACanaryTestUser
 } from "../utils/featureFlags";
 
 import {
@@ -24,7 +25,10 @@ export const activityName = "IsUserInActiveSubsetActivity";
 
 const activityFunction = getActivityBody({
   enabledFeatureFlag: config.NH_PARTITION_FEATURE_FLAG,
-  isInActiveSubset: getIsInActiveSubset(getIsUserABetaTestUser())
+  isInActiveSubset: getIsInActiveSubset(
+    getIsUserABetaTestUser(),
+    getIsUserACanaryTestUser(config.CANARY_USERS_REGEX)
+  )
 });
 
 const activityFunctionHandler = createActivity(

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Those are all Environment variables needed by the application:
 | STORAGE_CONN_STRING              |  The connection string of the Storage Account                                                      | string | true     |
 | NOTIFICATIONS_QUEUE_NAME         |  The name of the queue that stores the Notification messages                                       | string | true     |
 | NH_PARTITION_FEATURE_FLAG        |  The type of FF enabled fot NH partition. Possible values: "none" - "all" - "beta" - "canary"      | string | true     |
-
+| CANARY_USERS_REGEX               |  The regex used to discriminate _canary users_                                                     | string | true     |
 
 
 ## Deploy

--- a/__mocks__/env-config.mock.ts
+++ b/__mocks__/env-config.mock.ts
@@ -17,5 +17,6 @@ export const envConfig: IConfig = {
 
   NH_PARTITION_FEATURE_FLAG: "all",
   BETA_USERS_STORAGE_CONNECTION_STRING: "Endpoint=sb://host.docker.internal:30000;SharedAccessKeyName=DefaultFullSharedAccessSignature;SharedAccessKey=foobar" as NonEmptyString,
-  BETA_USERS_TABLE_NAME: "nhpartitiontestusers" as NonEmptyString
+  BETA_USERS_TABLE_NAME: "nhpartitiontestusers" as NonEmptyString,
+  CANARY_USERS_REGEX: "^([(0-9)|(a-f)|(A-F)]{63}0)|([(0-9)|(a-f)|(A-F)]{62}[(0-7)]{1}1)$" as NonEmptyString
 };

--- a/env.example
+++ b/env.example
@@ -32,6 +32,18 @@ NH_PARTITION_FEATURE_FLAG=none
 
 BETA_USERS_STORAGE_CONNECTION_STRING=${STORAGE_CONN_STRING}
 BETA_USERS_TABLE_NAME=nhpartitiontestusers
+CANARY_USERS_REGEX=^([(0-9)|(a-f)]{63}0)|([(0-9)|(a-f)]{62}[(0-7)]{1}1)$
+
+
+# ------------------------------------
+# Variable used during transition to new NH management
+# ------------------------------------
+
+# Possible values : "none" | "all" | "beta" | "canary"
+NH_PARTITION_FEATURE_FLAG=none
+
+BETA_USERS_STORAGE_CONNECTION_STRING=${STORAGE_CONN_STRING}
+BETA_USERS_TABLE_NAME=nhpartitiontestusers
 
 
 # ------------------------------------

--- a/utils/__tests__/featureFlags.test.ts
+++ b/utils/__tests__/featureFlags.test.ts
@@ -1,7 +1,12 @@
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { InstallationId } from "../../generated/notifications/InstallationId";
 import * as featureFlags from "../featureFlags";
 
+import { envConfig } from "../../__mocks__/env-config.mock";
+
 const aFiscalCodeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
+
+const canaryRegex = envConfig.CANARY_USERS_REGEX;
 
 describe("featureFlags", () => {
   beforeAll(() => {
@@ -9,38 +14,34 @@ describe("featureFlags", () => {
   });
 
   it("should return true when feature flag all is enabled", () => {
-    const res = featureFlags.getIsInActiveSubset(_ => false)(
-      "all",
-      aFiscalCodeHash,
-      [{ RowKey: aFiscalCodeHash }]
-    );
+    const res = featureFlags.getIsInActiveSubset(
+      _ => false,
+      _ => false
+    )("all", aFiscalCodeHash, [{ RowKey: aFiscalCodeHash }]);
     expect(res).toBe(true);
   });
 
   it("should return false when feature flag none is enabled", () => {
-    const res = featureFlags.getIsInActiveSubset(_ => true)(
-      "none",
-      aFiscalCodeHash,
-      [{ RowKey: aFiscalCodeHash }]
-    );
+    const res = featureFlags.getIsInActiveSubset(
+      _ => true,
+      _ => false
+    )("none", aFiscalCodeHash, [{ RowKey: aFiscalCodeHash }]);
     expect(res).toBe(false);
   });
 
   it("should return true when feature flag beta is enabled adn user is a beta test user", () => {
-    const res = featureFlags.getIsInActiveSubset(_ => true)(
-      "beta",
-      aFiscalCodeHash,
-      [{ RowKey: aFiscalCodeHash }]
-    );
+    const res = featureFlags.getIsInActiveSubset(
+      _ => true,
+      _ => false
+    )("beta", aFiscalCodeHash, [{ RowKey: aFiscalCodeHash }]);
     expect(res).toBe(true);
   });
 
   it("should return false when feature flag beta is enabled adn user is NOT a beta test user", () => {
-    const res = featureFlags.getIsInActiveSubset(_ => false)(
-      "beta",
-      aFiscalCodeHash,
-      [{ RowKey: aFiscalCodeHash }]
-    );
+    const res = featureFlags.getIsInActiveSubset(
+      _ => false,
+      _ => false
+    )("beta", aFiscalCodeHash, [{ RowKey: aFiscalCodeHash }]);
     expect(res).toBe(false);
   });
 });
@@ -61,5 +62,41 @@ describe("getIsUserABetaTestUser", () => {
   it("should return false if sha is NOT contained in beta users table", () => {
     const res = featureFlags.getIsUserABetaTestUser()([], aFiscalCodeHash);
     expect(res).toBe(false);
+  });
+});
+
+describe("getIsUserACanaryTestUser", () => {
+  beforeAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it("isUserACanaryTestUser should return true if sha is a valid installationId for regex", () => {
+    const validInstallationId = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b850" as InstallationId;
+    const validInstallationId2 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b851" as InstallationId;
+
+    const isUserABetaTestUser = featureFlags.getIsUserACanaryTestUser(
+      canaryRegex
+    );
+
+    const test1 = isUserABetaTestUser(validInstallationId);
+    expect(test1).toBeTruthy();
+
+    const test3 = isUserABetaTestUser(validInstallationId2);
+    expect(test3).toBeTruthy();
+  });
+
+  it("isUserACanaryTestUser should return flase if sha is NOT a valid installationId for regex", () => {
+    const invalidInstallationId = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as InstallationId;
+    const invalidInstallationId2 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b891" as InstallationId;
+
+    const isUserABetaTestUser = featureFlags.getIsUserACanaryTestUser(
+      canaryRegex
+    );
+
+    const test2 = isUserABetaTestUser(invalidInstallationId);
+    expect(test2).toBeFalsy();
+
+    const test4 = isUserABetaTestUser(invalidInstallationId2);
+    expect(test4).toBeFalsy();
   });
 });

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -41,6 +41,7 @@ export const IConfig = t.intersection([
   t.interface({
     BETA_USERS_STORAGE_CONNECTION_STRING: NonEmptyString,
     BETA_USERS_TABLE_NAME: NonEmptyString,
+    CANARY_USERS_REGEX: NonEmptyString,
     NH_PARTITION_FEATURE_FLAG: NHPartitionFeatureFlag
   }),
   t.partial({ APPINSIGHTS_DISABLE: t.string })

--- a/utils/featureFlags.ts
+++ b/utils/featureFlags.ts
@@ -10,7 +10,8 @@ import { NHPartitionFeatureFlag } from "./config";
  * @returns `true` if the user is enabled for the new feature, `false` otherwise
  */
 export const getIsInActiveSubset = (
-  isUserATestUser: ReturnType<typeof getIsUserABetaTestUser>
+  isUserATestUser: ReturnType<typeof getIsUserABetaTestUser>,
+  isUserACanaryUser: ReturnType<typeof getIsUserACanaryTestUser>
 ) => (
   enabledFeatureFlag: NHPartitionFeatureFlag,
   sha: InstallationId,
@@ -23,8 +24,7 @@ export const getIsInActiveSubset = (
     case "beta":
       return isUserATestUser(betaUsersTable, sha);
     case "canary":
-      // Todo
-      return false;
+      return isUserACanaryUser(sha) || isUserATestUser(betaUsersTable, sha);
     case "none":
       return false;
   }
@@ -39,3 +39,16 @@ export const getIsUserABetaTestUser = () => (
   betaUsersTable: ReadonlyArray<{ readonly RowKey: string }>,
   sha: InstallationId
 ): boolean => betaUsersTable.filter(u => u.RowKey === sha).length > 0;
+
+/**
+ *
+ * @param regex The regex to use
+ * @returns
+ */
+export const getIsUserACanaryTestUser = (
+  regex: string
+): ((sha: InstallationId) => boolean) => {
+  const regExp = new RegExp(regex);
+
+  return (sha: InstallationId): boolean => regExp.test(sha);
+};


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Added functions to return if a user (defined by his sha) is a canary test user
- The regex that has beed used is `^([(0-9)|(a-f)]{63}0)|([(0-9)|(a-f)]{62}[(0-7)]{1}1)$`

#### TODO
<!--- Describe your changes in detail -->
- Add new env variables in terraform (staging + prod)
- Add new storage account in terraform

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
IP-27 We need a Feture Flag mechanism that can allow to test the new feature only for a subset of users so we can gradually release the new NH implementation
In order to create a set of canary users, we added a function that tests a sha based on a regex, retrieved from `.env` file.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
By performing Unit Tests and Integration test using the Sandbox NH

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
